### PR TITLE
Fixed behavior where height changes were not reflected unless during timer measurement.

### DIFF
--- a/VideoSettings.cs
+++ b/VideoSettings.cs
@@ -83,7 +83,7 @@ namespace LiveSplit.Video
             SettingsHelper.CreateSetting(document, parent, "VideoPath", VideoPath) ^
             SettingsHelper.CreateSetting(document, parent, "Offset", OffsetString) ^
             SettingsHelper.CreateSetting(document, parent, "Height", Height) ^
-            SettingsHelper.CreateSetting(document, parent, "Width", Height);
+            SettingsHelper.CreateSetting(document, parent, "Width", Width);
         }
 
         private void btnSelectFile_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Fixed behavior where height changes were not reflected unless during timer measurement.
- Fixed a behavior in which width settings were not saved correctly in horizontal layouts.