### PR TITLE
Fix OffsetString regex to allow minus sign

### DIFF
--- a/src/LiveSplit.Video/VideoSettings.cs
+++ b/src/LiveSplit.Video/VideoSettings.cs
@@ -28,7 +28,9 @@ public partial class VideoSettings : UserControl
         get => TimeFormatter.Format(Offset);
         set
         {
-            if (Regex.IsMatch(value, "[^0-9:.,-]"))
+            // The ordering here is significant. If the DASH isn't last the expression attempts to match on a range.
+            string negative_pattern = "[^0-9:.," + TimeFormatConstants.MINUS + TimeFormatConstants.DASH + "]";
+            if (Regex.IsMatch(value, negative_pattern))
             {
                 return;
             }


### PR DESCRIPTION
# Issue
Negative values are allowed for the Run Starts At time in the component settings.  However, when that value gets formatted and saved into the layout XML, the dash character that a user types with their keyboard is converted into a minus character.  When reloading the layout after save, the offset time is set to 0.0 instead of the saved negative value.

# Implementation
The current regex allows a dash character but not a minus character, though the TimeFormatter converts the dash into a minus.  Updated the regex pattern to use the MINUS and DASH constants defined in LiveSplit to allow both characters in an offset string.

# Testing
I built and tested this component myself and verified it works as intended.  Entering a negative offset value from my keyboard, which inputs a dash, is saved as expected and loads correctly when the layout is loaded.  The video also starts at the correct offset.  Also, I manually edited the layout xml to test both minus and dash characters in the offset string are loaded correctly and the video starts at the correct offset in both cases.